### PR TITLE
configure git to not check directory ownership when interacting with repositories

### DIFF
--- a/devel/ansible/matrixbots.yml
+++ b/devel/ansible/matrixbots.yml
@@ -9,6 +9,7 @@
     krb_realm: TINYSTAGE.TEST
 
   roles:
+    - common
     - ipa-client
     - synapse
     - nginx

--- a/devel/ansible/roles/common/tasks/main.yml
+++ b/devel/ansible/roles/common/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Install common packages
+  dnf:
+    name:
+    - git
+    state: present
+
+- name: set git to ignore safety warnings added in git 2.36 https://github.blog/2022-04-18-highlights-from-git-2-36/#stricter-repository-ownership-checks 
+  command: git config --global --add safe.directory /home/vagrant/

--- a/devel/ansible/roles/common/tasks/main.yml
+++ b/devel/ansible/roles/common/tasks/main.yml
@@ -6,4 +6,4 @@
     state: present
 
 - name: set git to ignore safety warnings added in git 2.36 https://github.blog/2022-04-18-highlights-from-git-2-36/#stricter-repository-ownership-checks 
-  command: git config --global --add safe.directory /home/vagrant/
+  command: git config --global --add safe.directory '*'

--- a/devel/ansible/roles/common/tasks/main.yml
+++ b/devel/ansible/roles/common/tasks/main.yml
@@ -7,3 +7,4 @@
 
 - name: set git to ignore safety warnings added in git 2.36 https://github.blog/2022-04-18-highlights-from-git-2-36/#stricter-repository-ownership-checks 
   command: git config --global --add safe.directory '*'
+  become_user: vagrant


### PR DESCRIPTION
This applies a very similar fix to one I made in https://github.com/fedora-infra/tiny-stage/pull/61 to resolve the same issue with the tiny-stage portion of the environment.

TL;DR i think the shared folder in vagrant causes a new security feature in git to activate  for safety, causing the ansible setup scripts to fail. Because this is a dev environment and not a shared/prod environment, it seems safe to disable this security feature as the reason it was added likely doesn't apply

more info/details/links in the PR referenced above
