### PR TITLE
Document issues connecting to the test server for future newcomers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,13 @@ Log into this server (with your matrix client of choice) with the following deta
 * **password:** `password`
 * **homeserver:** `http://matrixbots.tinystage.test`
 
+Because this is a locally-hosted matrix server that is not (and should not be) available through public DNS, matrix clients toat do lookups of public instances may have trouble connecting to it. These non-working clients may include clients like:
+- nheko
+- Element or other web-based clients
+
+Known-working clients include
+- Quaternion
+
 ### maubot admin interface
 
 The maubot admin interface is available at: 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ Log into this server (with your matrix client of choice) with the following deta
 * **password:** `password`
 * **homeserver:** `http://matrixbots.tinystage.test`
 
-Because this is a locally-hosted matrix server that is not (and should not be) available through public DNS, matrix clients toat do lookups of public instances may have trouble connecting to it. These non-working clients may include clients like:
+Because this is a locally-hosted matrix server for development purposes, it is not (and should not be) included on [lists of public matrix servers](https://servers.joinmatrix.org/). Many matrix clients use these lists to look up homeservers. Clients that do this will be unable to find this locally hosted homeserver, this includes:
 - nheko
 - Element or other web-based clients
 
-Known-working clients include
+In order to be able to find the homeserver, clients need to be able to perform a lookup using the typical DNS lookup process (which /etc/hosts is part of). Here are some clients that appear to work:
 - Quaternion
 
 ### maubot admin interface


### PR DESCRIPTION
I had some issues connecting to the homeserver as many matrix clients I tried were attempting to query either a list of known public servers (such as https://servers.joinmatrix.org/) or (i assume) look up the homeserver using public DNS.

Because this is a local environment, it will only be discoverable if /etc/hosts is part of the lookup process that the matrix client uses.

This PR adds a note to the README along with some positive and negative examples of clients that I personally tried and found to either work or not work. 