### PR TITLE
Include eventbot in the dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ _mote/
 _maubot-fedora/
 _maubot-meetings/
 _maubot-pagure-notifications/
+_maubot-events/
+

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ These clones are also mounted (and synced to the VM) and available on the host m
 
 * _maubot-fedora
 * _maubot-meetings
+* _maubot-events
 * _mote
 
 If you make changes to the plugins and want to update them on the maubot instance, wun commands like this on the VM:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Fedora Infrastructure runs a Maubot instance, that deploys the following bots:
   * [maubot-pagure-notifications](https://github.com/fedora-infra/maubot-pagure-notifications)
   * [maubot-adminclient](https://github.com/fedora-infra/maubot-adminclient)
 
+* **eventbot**
+  eventbot is a bot used to assist with hosting fedora virtual events on matrix, such as automatically inviting attendees from the pretix.eu ticketing platform
+
+  This bot is installed with the following maubot plugins:
+  * [maubot-pretix-invite](https://github.com/fedora-infra/maubot-pretix-invites)
 
 # Matrix bots development environment
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,7 @@ Vagrant.configure(2) do |config|
     matrixbots.vm.synced_folder "_maubot-meetings/", "/home/vagrant/_maubot-meetings", type: "sshfs", create: true
     matrixbots.vm.synced_folder "_maubot-fedora/", "/home/vagrant/_maubot-fedora", type: "sshfs", create: true
     matrixbots.vm.synced_folder "_maubot-pagure-notifications/", "/home/vagrant/_maubot-pagure-notifications", type: "sshfs", create: true
+    matrixbots.vm.synced_folder "_maubot-events/", "/home/vagrant/_maubot-events", type: "sshfs", create: true
     matrixbots.vm.synced_folder ".", "/vagrant", disabled: true
 
     matrixbots.vm.provider :libvirt do |libvirt|

--- a/devel/ansible/roles/chatenv/tasks/main.yml
+++ b/devel/ansible/roles/chatenv/tasks/main.yml
@@ -27,7 +27,7 @@
     chdir: /home/vagrant/
 
 - name: invite the bots to the testroom -- they should autoaccept
-  command: matrix-commander --room-invite '#testroom:matrixbots.tinystage.test' --user '@zodbot:matrixbots.tinystage.test' '@meetbot:matrixbots.tinystage.test' '@nonbot:matrixbots.tinystage.test'
+  command: matrix-commander --room-invite '#testroom:matrixbots.tinystage.test' --user '@zodbot:matrixbots.tinystage.test' '@meetbot:matrixbots.tinystage.test' '@nonbot:matrixbots.tinystage.test' '@eventbot:matrixbots.tinystage.test'
   become: True
   become_user: vagrant
   args:

--- a/devel/ansible/roles/maubot/files/eventbot-instance.json
+++ b/devel/ansible/roles/maubot/files/eventbot-instance.json
@@ -1,0 +1,8 @@
+{
+    "id": "eventbot",
+    "type": "com.ansible.events",
+    "enabled": true,
+    "started": true,
+    "primary_user": "@eventbot:matrixbots.tinystage.test",
+    "config": "powerlevel: 0\nbackend: fedora\nbackend_data:\n    fedora:\n        logs_baseurl: http://matrixbots.tinystage.test:9696/\n        logs_directory: /srv/web/eventbot/\n        fasjson_url: https://fasjson.tinystage.test/fasjson\ntags_command_at_start: true\ntags_command_prefix: '!'\ntags:\n    action: 🚩\n    info: ✏️\n    agreed: 👍\n    rejected: 👎\n    idea: 💭\n    halp: 🛟\n    link: 🔗"
+}

--- a/devel/ansible/roles/maubot/tasks/main.yml
+++ b/devel/ansible/roles/maubot/tasks/main.yml
@@ -159,6 +159,11 @@
   become: True
   become_user: vagrant
 
+- name: add eventbot user from synapse as a client
+  command: mbc auth -c --homeserver matrixbots.tinystage.test --username eventbot --password password
+  become: True
+  become_user: vagrant
+
 - name: stuff auth token into a variable
   shell: 
     cmd: cat /home/vagrant/.config/maubot-cli.json | jq -r '.servers."http://matrixbots.tinystage.test:29316"'

--- a/devel/ansible/roles/maubot/tasks/main.yml
+++ b/devel/ansible/roles/maubot/tasks/main.yml
@@ -129,6 +129,21 @@
 #   args:
 #     chdir: /home/vagrant/_maubot-meetings
 
+
+- name: get maubot-events
+  git:
+    repo: https://github.com/MoralCode/maubot-events.git
+    dest: /home/vagrant/_maubot-events
+  become: True
+  become_user: vagrant
+
+- name: build and install the events plugin to maubot
+  command: mbc build -u
+  become: True
+  become_user: vagrant
+  args:
+    chdir: /home/vagrant/_maubot-events
+
 - name: add zodbot user from synapse as a client
   command: mbc auth -c --homeserver matrixbots.tinystage.test --username zodbot --password password
   become: True
@@ -171,5 +186,13 @@
   become: True
   become_user: vagrant
 
+- name: copy config file for eventbot plugin
+  copy:
+      src: eventbot-instance.json
+      dest: /var/tmp/eventbot-instance.json
 
+- name: create eventbot instance of events plugin
+  command: curl -v -X PUT http://matrixbots.tinystage.test:29316/_matrix/maubot/v1/instance/eventbot?access_token={{auth_token.stdout}} -d @/var/tmp/eventbot-instance.json
+  become: True
+  become_user: vagrant
   

--- a/devel/ansible/roles/synapse/tasks/main.yml
+++ b/devel/ansible/roles/synapse/tasks/main.yml
@@ -38,6 +38,9 @@
 - name: add a nonbot account to the matrix server
   command: register_new_matrix_user -u nonbot -p password -c /etc/synapse/homeserver.yaml --no-admin
 
+- name: add a eventbot account to the matrix server
+  command: register_new_matrix_user -u eventbot -p password -c /etc/synapse/homeserver.yaml --no-admin
+
 - name: add a aaronhale account to the matrix server
   command: register_new_matrix_user -u aaronhale -p password -c /etc/synapse/homeserver.yaml --no-admin
 


### PR DESCRIPTION
I have recently been working on a new bot to assist with running fedora events such as the F40 release party and Fedora Week of Diversity.

The bot was developed primarily using this development environment and I wanted to contribute the changes I made to set up the homeserver users and other things to get this bot running (which is how the screenshots in the [README](https://github.com/fedora-infra/maubot-pretix-invite/blob/main/README.md) and the testing were largely conducted)